### PR TITLE
Add OBS LiveSplit One plugin

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -215,5 +215,11 @@
         "commits": {
             "1.5.0-beta.5": "ccefae9878a0d0547d14aedbb2c0521d5573ec10"
         }
+    },
+    {
+        "url": "https://github.com/pniedzielski/StreamController-OBSLiveSplitOnePlugin",
+        "commits": {
+            "1.5.0-beta.5": "9cbb36ea809d47fb74049ed3eabd3b00fc2f000a"
+        }
     }
 ]


### PR DESCRIPTION
This PR adds a plugin to control the LiveSplit One source plugin for OBS using the OBS websocket interface.
Currently, you can split, undo and skip splits, change your timing comparison and timing method, and reset your attempt.

### Checks
- [X] I tested my changes or release
- [X] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)

I tested against the current `main` of StreamController in a flatpak build.