### PR TITLE
Update twitch to 1.2.1

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -203,7 +203,7 @@
         "commits": {
             "1.5.0-beta.4": "f0ccf9a77f9ecf024978eeb0bcf53dea2dc084e5",
             "1.5.0-beta.5": "22d53051ee483ed4bf03ca7df47f3c5a8a1b6490",
-            "1.5.0-beta.6": "c908ed7224d870249a81b3e6b078a17afe8fdc41"
+            "1.5.0-beta.6": "1c235999bb3933f6f5c1926bdfed5b11f3269794"
         }
     },
     {


### PR DESCRIPTION
This fixes an issue when using the plugin in a python install instead of Flatpak.
Since StreamController uses a different virtualenv than the plugin, the plugin doesn't
have access to the packages installed there. This makes sure those libraries exist.

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)
