### PR TITLE
Bump Spotify plugin version to 0.1.1-beta

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -277,7 +277,7 @@
     {
         "url": "https://github.com/ReneLu/SpotifyControl",
         "commits": {
-            "1.5.0-beta.10": "dd2e813ca425c361b547334576ff54d6ba6c249b"
+            "1.5.0-beta.11": "8510d34bb4ac43f8483a758a3ca87cc5f08f1181"
         }
     },
     {

--- a/Plugins.json
+++ b/Plugins.json
@@ -277,7 +277,7 @@
     {
         "url": "https://github.com/ReneLu/SpotifyControl",
         "commits": {
-            "1.5.0-beta.11": "8510d34bb4ac43f8483a758a3ca87cc5f08f1181"
+            "1.5.0-beta.11": "cdc46acce611c3301b5999258e08626503267f4a"
         }
     },
     {


### PR DESCRIPTION
I forgot to also update the version of my plugin in the manifest.json.

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)