### PR TITLE
Add tyvsmith/streamcontroller-lg-monitor-control

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -401,5 +401,11 @@
         "commits": {
             "0.1.0": "00d2597dbda67c8b90063afe6101da69a98dea97"
         }
+    },
+    {
+        "url": "https://github.com/tyvsmith/streamcontroller-lg-monitor-control",
+        "commits": {
+            "1.5.0-beta": "513b966b535b81f13ab566d2212bfd545fcee22f"
+        }
     }
 ]


### PR DESCRIPTION
## Summary

Adding [LG Monitor Controls](https://github.com/tyvsmith/streamcontroller-lg-monitor-control) plugin to the Store.

Control monitor inputs, PBP, brightness, volume, contrast, sharpness, black stabilizer, and power via ddcutil DDC/CI. Tested on LG 45GX950A — other DDC/CI monitors may work but compatibility varies. Contributions and monitor profiles welcome.

**Plugin ID:** `me_tysmith_LgMonitorControls`
**Version:** 0.1.0

Checks
 - [X] I tested my changes or release
 - [X] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)