### PR TITLE
Add lan-mouse plugin entry for StreamController 1.5.0-beta

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -399,7 +399,8 @@
     {
         "url": "https://github.com/tyvsmith/streamcontroller-lan-mouse",
         "commits": {
-            "0.1.0": "00d2597dbda67c8b90063afe6101da69a98dea97"
+            "0.1.0": "00d2597dbda67c8b90063afe6101da69a98dea97",
+            "1.5.0-beta": "c18fd0ab1304b0e869c642c62bc51bddfcaa8833"
         }
     }
 ]


### PR DESCRIPTION
Adds a 1.5.0-beta entry pointing to plugin v0.2.0 alongside the existing 0.1.0 entry, so users on the new SC release can install the compatible plugin build.

### Checks
- [X] I tested my changes or release
- [X] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)