### PR TITLE
Add new plugin StreamController-BetterVolumeMixer

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -410,4 +410,10 @@
             "1.5.0-beta": "513b966b535b81f13ab566d2212bfd545fcee22f"
         }
     }
+    {
+        "url": "https://github.com/Dav1d-Fn/StreamController-BetterVolumeMixer",
+        "commits": {
+            "1.0.0": "10c7315ea5bc3e2e3de83769df9b54725a3a0487"
+        }
+    }
 ]


### PR DESCRIPTION
Adds the BetterVolumeMixer plugin by Dav1d-Fn.

A per-app audio mixer for StreamController that brings PulseAudio/PipeWire volume control to the Stream Deck. Features include per-app volume control, live app display with icon and volume, priority sorting, custom icons (PNG/SVG/GIF), page navigation, and export/import of settings.

https://github.com/Dav1d-Fn/BetterVolumeMixer

### Checks
- [X ] I tested my changes or release
- [ X] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)