### PR TITLE
Add new plugin StreamController-BetterVolumeMixer

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -410,4 +410,10 @@
             "1.5.0-beta": "513b966b535b81f13ab566d2212bfd545fcee22f"
         }
     }
+    {
+        "url": "https://github.com/Dav1d-Fn/StreamController-BetterVolumeMixer",
+        "commits": {
+            "1.0.0": "5f2059a24d7e0ac15b1c5205ae3b5ea29c31aec4"
+        }
+    }
 ]

--- a/Plugins.json
+++ b/Plugins.json
@@ -413,7 +413,7 @@
     {
         "url": "https://github.com/Dav1d-Fn/StreamController-BetterVolumeMixer",
         "commits": {
-            "1.0.0": "5f2059a24d7e0ac15b1c5205ae3b5ea29c31aec4"
+            "1.0.0": "ae64cfb0dd33d4b77702487166e4c47223e5f42c"
         }
     }
 ]

--- a/Plugins.json
+++ b/Plugins.json
@@ -409,7 +409,7 @@
         "commits": {
             "1.5.0-beta": "513b966b535b81f13ab566d2212bfd545fcee22f"
         }
-    }
+    },
     {
         "url": "https://github.com/Dav1d-Fn/StreamController-BetterVolumeMixer",
         "commits": {


### PR DESCRIPTION
Adds the BetterVolumeMixer plugin by Dav1d-Fn.

A per-app audio mixer for StreamController that brings PulseAudio/PipeWire volume control to the Stream Deck. Features include per-app volume control, live app display with icon and volume, priority sorting, custom icons (PNG/SVG/GIF), page navigation, and export/import of settings.

https://github.com/Dav1d-Fn/StreamController-BetterVolumeMixer

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)