### PR TITLE
Add Tailscale plugin

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -415,5 +415,11 @@
         "commits": {
             "1.0.0": "ae64cfb0dd33d4b77702487166e4c47223e5f42c"
         }
+    },
+    {
+        "url": "https://github.com/benwyrosdick/streamdeck-tailscale",
+        "commits": {
+            "1.0.0": "61c1ba5940353b5dbf28e2edefc10c56e35ca061"
+        }
     }
 ]


### PR DESCRIPTION
Adds the **Tailscale** plugin — control the local Tailscale daemon from a Stream Deck.

- Repo: https://github.com/benwyrosdick/streamdeck-tailscale
- Version: `1.0.0` → commit `61c1ba5940353b5dbf28e2edefc10c56e35ca061`
- Actions: Connect, Disconnect, Toggle Connection (status-aware), Switch Account, Toggle Exit Node (per-network with automatic fallback)
- Stdlib only (no extra requirements); talks to the host `tailscale` CLI.

Unofficial community plugin; not affiliated with or endorsed by Tailscale Inc. (noted in `about.json`/`attribution.json`).

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)

