### PR TITLE
update(helldivers_2): update hash for main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -98,7 +98,7 @@
   {
     "url": "https://github.com/jslay88/streamcontroller_helldivers_2",
     "commits": {
-      "1.5.0-beta": "cc669aa8e81fba929e4b086747c98d03c563414b"
+      "1.5.0-beta": "64e06e644a5a7edea68d4605443acc5f63cbcfa6"
     }
   },
   {


### PR DESCRIPTION
Updates the HELLDIVERS 2 plugin (`jslay88/streamcontroller_helldivers_2`) to the latest `main` commit `64e06e644a5a7edea68d4605443acc5f63cbcfa6` (v2.3.0).

This release adds a configurable **Direction Keys** setting (Arrow keys / WASD) for stratagem inputs, with Arrow keys remaining the backward-compatible default.

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)