### PR TITLE
Add github plugin v1.0.0

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -318,6 +318,12 @@
     }
   },
   {
+    "url": "https://github.com/benwyrosdick/streamdeck-github",
+    "commits": {
+      "1.5.0-beta": "7f35abc0a4ae3ed2206d8a7d5853e09bbc382f05"
+    }
+  },
+  {
     "url": "https://github.com/MiguelAngelLV/streamcontroller-steam",
     "commits": {
       "1.5.0-beta": "7843d04e5ae8b23ac4a1902778e50ca454974c22"


### PR DESCRIPTION
# GitHub Insights

https://github.com/benwyrosdick/streamdeck-github

## Actions

| Action | What it does |
| --- | --- |
| **PR Count** | Shows a live count of pull requests in a repo matching a filter (author, approval status, labels, state). Press the key to open the equivalent GitHub PR search in your browser. |
| **Issue Count** | Shows a live count of issues in a repo matching a filter (author, assignee, labels, state). Press the key to open the equivalent GitHub issue search in your browser. |
| **CI Status** | Shows the status of the latest GitHub Actions run for a repo — green ✓ (success), red ✗ (failure), amber ↻ (in progress), grey dots (queued / waiting), grey dash (no runs / cancelled). While a run is in progress it also shows live step progress (e.g. `4 / 9`) at the bottom. Press to open the run (or the repo's Actions page) in your browser. |
| **Notification Count** | Shows a live count of your unread GitHub notifications, optionally scoped to a single repo and to a common inbox filter (Assigned, Participating, Mentioned, Team mentioned, Review requested). Press the key to open the matching GitHub notifications view. |

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)