### PR TITLE
update(helldivers_2): update hash for main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -98,7 +98,7 @@
   {
     "url": "https://github.com/jslay88/streamcontroller_helldivers_2",
     "commits": {
-      "1.5.0-beta": "cc669aa8e81fba929e4b086747c98d03c563414b"
+      "1.5.0-beta": "96515e5792d3a78e0df315b2817cfa2d6d79b964"
     }
   },
   {

--- a/Plugins.json
+++ b/Plugins.json
@@ -98,7 +98,7 @@
   {
     "url": "https://github.com/jslay88/streamcontroller_helldivers_2",
     "commits": {
-      "1.5.0-beta": "96515e5792d3a78e0df315b2817cfa2d6d79b964"
+      "1.5.0-beta": "55aebf4c6a9442fce13b4ba0c32971db5b7cdb03"
     }
   },
   {


### PR DESCRIPTION
## Summary
- Bump `streamcontroller_helldivers_2` to `96515e5792d3a78e0df315b2817cfa2d6d79b964` (v2.3.1)
- Fixes plugin failing to load since v2.3.0 (`No module named 'key_mapping'`)

## Test plan
- [x] Store install/update pulls v2.3.1
- [x] StreamController loads all HELLDIVERS 2 actions on existing pages

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)