### PR TITLE
Update Spotify Control to version 0.2.1-beta

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -176,7 +176,7 @@
   {
     "url": "https://github.com/ReneLu/SpotifyControl",
     "commits": {
-      "1.5.0-beta": "adda0cca97c185e234fc2b1bda6b8de75c85af9d"
+      "1.5.0-beta": "4125e16a261bbbe26d5e19280bf163bc3026192e"
     }
   },
   {


### PR DESCRIPTION
Rename settings.py to prevent clash with Media Plugin

### Checks
- [X] I tested my changes or release
- [X] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)