### PR TITLE
Add Codex Usage plugin

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -365,5 +365,11 @@
     "commits": {
       "1.1.2": "f035f2fd47d720d7085b28f90c788931794da721"
     }
+  },
+  {
+    "url": "https://github.com/seipass/CodexUsageInLinuxTreamDeck",
+    "commits": {
+      "1.5.0": "08206c325f8756e13777db85163fe33e6a06b487"
+    }
   }
 ]

--- a/Plugins.json
+++ b/Plugins.json
@@ -369,7 +369,7 @@
   {
     "url": "https://github.com/seipass/CodexUsageInLinuxTreamDeck",
     "commits": {
-      "1.5.0": "08206c325f8756e13777db85163fe33e6a06b487"
+      "1.5.0": "9f39b746010d47fc26cb22e15e6ed842f5563176"
     }
   }
 ]


### PR DESCRIPTION
Adds https://github.com/seipass/CodexUsageInLinuxTreamDeck to Plugins.json.

This makes the plugin discoverable in the built-in StreamController Store.
It displays the remaining Codex rate limit using the existing Codex login
without reading authentication files directly.

The plugin includes a Store-compatible PNG thumbnail at `assets/thumbnail.png`.

Tested with StreamController 1.5.0.
Plugin commit: 9f39b746010d47fc26cb22e15e6ed842f5563176

Validation:
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q codex_usage main.py tests`
- `python3 -m json.tool Plugins.json`
- `git diff --check`