### PR TITLE
Update OSPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -20,7 +20,7 @@
   {
     "url": "https://github.com/StreamController/OSPlugin",
     "commits": {
-      "1.5.0-beta": "0056970ceed3707fe902c6cebe748b6eaa5b8c7b"
+      "1.5.0-beta": "041d8955f58273ae566ba46cd1a24fbdc43bf14d"
     }
   },
   {


### PR DESCRIPTION
Automated update of commit hash for plugin: OSPlugin
- **Version/Branch:** main
- **Commit SHA:** 041d8955f58273ae566ba46cd1a24fbdc43bf14d