### PR TITLE
Update DeckPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -14,7 +14,7 @@
   {
     "url": "https://github.com/StreamController/DeckPlugin",
     "commits": {
-      "1.5.0-beta": "dd053be1d541034d53b7bebf87125979fd7cdc0c"
+      "1.5.0-beta": "2165dbba12ef724c3b08cc3d348d35a0d024abe0"
     }
   },
   {


### PR DESCRIPTION
Automated update of commit hash for plugin: DeckPlugin
- **Version/Branch:** main
- **Commit SHA:** 2165dbba12ef724c3b08cc3d348d35a0d024abe0