### PR TITLE
Update DeckPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -14,7 +14,7 @@
   {
     "url": "https://github.com/StreamController/DeckPlugin",
     "commits": {
-      "1.5.0-beta": "dd053be1d541034d53b7bebf87125979fd7cdc0c"
+      "1.5.0-beta": "63ee7c88740222ad400ef6a3a8598dcf1b27864d"
     }
   },
   {


### PR DESCRIPTION
Automated update of commit hash for plugin: DeckPlugin
- **Version/Branch:** main
- **Commit SHA:** 63ee7c88740222ad400ef6a3a8598dcf1b27864d