### PR TITLE
Update DeckPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -14,7 +14,7 @@
   {
     "url": "https://github.com/StreamController/DeckPlugin",
     "commits": {
-      "1.5.0-beta": "63ee7c88740222ad400ef6a3a8598dcf1b27864d"
+      "1.5.0-beta": "fa8b5f965971f618f1c15dd5e4a4843dbfa08057"
     }
   },
   {


### PR DESCRIPTION
Automated update of commit hash for plugin: DeckPlugin
- **Version/Branch:** main
- **Commit SHA:** fa8b5f965971f618f1c15dd5e4a4843dbfa08057