### PR TITLE
Update DeckPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -14,7 +14,7 @@
   {
     "url": "https://github.com/StreamController/DeckPlugin",
     "commits": {
-      "1.5.0-beta": "fa8b5f965971f618f1c15dd5e4a4843dbfa08057"
+      "1.5.0-beta": "e99ef07b992c4fcbf31b5f7b0dd7e17b221931ef"
     }
   },
   {


### PR DESCRIPTION
Automated update of commit hash for plugin: DeckPlugin
- **Version/Branch:** main
- **Commit SHA:** e99ef07b992c4fcbf31b5f7b0dd7e17b221931ef