### PR TITLE
Add Claude Code Usage plugin

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -369,7 +369,7 @@
   {
     "url": "https://github.com/ENjxzlt/Claude-Code-Usage-Streamcontroller",
     "commits": {
-        "1.5.0-beta.15": "1582694b90ccafc2d33dac6fb790ec1d0604c43c"
+        "1.5.0-beta": "1582694b90ccafc2d33dac6fb790ec1d0604c43c"
     }
   }    
 ]

--- a/Plugins.json
+++ b/Plugins.json
@@ -365,5 +365,11 @@
     "commits": {
       "1.5.0": "9f39b746010d47fc26cb22e15e6ed842f5563176"
     }
-  }
+  },
+  {
+    "url": "https://github.com/ENjxzlt/Claude-Code-Usage-Streamcontroller",
+    "commits": {
+        "1.5.0-beta.15": "1582694b90ccafc2d33dac6fb790ec1d0604c43c"
+    }
+  }    
 ]


### PR DESCRIPTION
### Checks
- [x ] I tested my changes or release
- [ x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)

Adds "Claude Usage" to Plugins.json.

Shows Claude Code's usage of the current 5-hour session block on a key as a
Claude-branded progress ring (percentage of a configurable token limit, or
raw token count), plus time remaining until it resets. Powered by ccusage,
which reads Claude Code's local session logs — no API key or login needed.
Disclaimer: This Plugin was entirely created using Claude Code!

- Repo: https://github.com/ENjxzlt/Claude-Code-Usage-Streamcontroller
- License: GPL-3.0
- Tested against: StreamController 1.5.0-beta