### PR TITLE
Update OSPlugin to main

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -13,7 +13,7 @@
   },
   {
     "url": "https://github.com/StreamController/OSPlugin",
-    "hash": "a8d943f41fe468fc4c978d3266fbfcf260e2598b"
+    "hash": "415a2a4be3dbd338593b0e6ad5d0d9ac79f71526"
   },
   {
     "url": "https://github.com/StreamController/Requests",


### PR DESCRIPTION
Automated update of commit hash for plugin: OSPlugin
- **Version/Branch:** main
- **Commit SHA:** 415a2a4be3dbd338593b0e6ad5d0d9ac79f71526