### PR TITLE
Add Bitfocus Companion, Discord, Litra Glow, and Spotify

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -246,5 +246,21 @@
   {
     "url": "https://github.com/ENjxzlt/Claude-Code-Usage-Streamcontroller",
     "hash": "1582694b90ccafc2d33dac6fb790ec1d0604c43c"
+  },
+  {
+    "url": "https://github.com/GrantAbell/StreamController-LitraGlow",
+    "hash": "9b63ac8971f7cee8a8a17c4619cc8ad9268ece55"
+  },
+  {
+    "url": "https://github.com/GrantAbell/StreamController-BitfocusCompanion",
+    "hash": "93a20ee6fc8d5a9ad8eec44559128e9b76d5d5e4"
+  },
+  {
+    "url": "https://github.com/GrantAbell/StreamController-DiscordPlugin",
+    "hash": "a5152b9085f691f440a6bbc323b5e85a22c9a6b3"
+  },
+  {
+    "url": "https://github.com/GrantAbell/StreamController-Spotify",
+    "hash": "4edd1b38ea468b0d5fc17e9dca2fd23696e3f2ce"
   }
 ]

--- a/Plugins.json
+++ b/Plugins.json
@@ -249,7 +249,7 @@
   },
   {
     "url": "https://github.com/GrantAbell/StreamController-LitraGlow",
-    "hash": "9b63ac8971f7cee8a8a17c4619cc8ad9268ece55"
+    "hash": "0ef049c753b104061fb7fe4653014c8963bdb9af"
   },
   {
     "url": "https://github.com/GrantAbell/StreamController-BitfocusCompanion",


### PR DESCRIPTION
Adds the following plugins:
- Bitfocus Companion
- Discord (forked from @ImDevinC's original plugin)
- Litra Glow
- Spotify

### Checks
- [x] I tested my changes or release
- [x] I agree to the [terms of service](https://streamcontroller.github.io/docs/latest/plugin_dev/submitting/terms/)